### PR TITLE
Maven hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.0</junit.version>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updated dependencies in pom.xml to target Java 21 rather than 11 / 17 / anything else.