### PR TITLE
WH-112-Integrate database query with Fortnightly minutes heatmap

### DIFF
--- a/src/main/resources/edu/qut/cab302/wehab/Visual-Progress-Tracking.fxml
+++ b/src/main/resources/edu/qut/cab302/wehab/Visual-Progress-Tracking.fxml
@@ -4,7 +4,6 @@
 <?import javafx.scene.chart.BarChart?>
 <?import javafx.scene.chart.CategoryAxis?>
 <?import javafx.scene.chart.NumberAxis?>
-<?import javafx.scene.chart.ScatterChart?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.DatePicker?>
@@ -87,18 +86,18 @@
                                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                                     </VBox.margin>
                                 </GridPane>
-                                <Label styleClass="heading" text="Minutes per day">
+                                <Label styleClass="heading" text="Monthly minutes per activity">
                                     <padding>
                                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                     </padding>
                                 </Label>
-                                <BarChart fx:id="minutesPerDayChart" legendSide="LEFT" prefHeight="216.0" prefWidth="422.0" style="-fx-border-color: #000000; -fx-background-color: #FFFFFF;">
-                                    <xAxis>
-                                        <CategoryAxis side="BOTTOM" />
+                                <BarChart fx:id="minutesPerDayChart" prefHeight="216.0" prefWidth="422.0" style="-fx-border-color: #000000; -fx-background-color: #FFFFFF;" barGap="2" categoryGap="5">                                    <xAxis>
+                                        <NumberAxis side="BOTTOM" label="Minutes" />
                                     </xAxis>
                                     <yAxis>
-                                        <NumberAxis side="LEFT" />
+                                        <CategoryAxis fx:id="workoutTypeAxis" side="LEFT" label="Workout Type" />
                                     </yAxis>
+                                    <legendVisible>false</legendVisible>
                                     <VBox.margin>
                                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                                     </VBox.margin>
@@ -107,11 +106,16 @@
                                     <children>
                                         <VBox alignment="TOP_CENTER" prefHeight="200.0" prefWidth="270.0" style="-fx-spacing: 10;">
                                             <children>
-                                                <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Add new workout">
-                                                    <font>
-                                                        <Font size="20.0" />
-                                                    </font>
-                                                </Text>
+<!--                                                <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Add new workout">-->
+<!--                                                    <font>-->
+<!--                                                        <Font size="20.0" />-->
+<!--                                                    </font>-->
+<!--                                                </Text>-->
+                                                <Label styleClass="heading" text="Add new workout">
+                                                    <padding>
+                                                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                                    </padding>
+                                                </Label>
                                                 <ComboBox fx:id="workoutTypeComboBox" prefHeight="30.0" prefWidth="120.0" />
                                                 <DatePicker fx:id="datePicker" prefHeight="30.0" prefWidth="120.0" />
                                                 <Spinner fx:id="durationSpinner" prefHeight="30.0" prefWidth="120.0" />


### PR DESCRIPTION
WH-112-Integrate database query with Fortnightly minutes heatmap

Task list:
- Add labels for each activity
- - Cycling
- - Rowing
- - Others
- Aggregate data based on activity for the month
- - Filter by activity type
- - Change orientation to horizontal
- - Add labels
- Changed Add new workout from text to label to ensure uniformity
- Increase width of bar graph bars.

TLDR:		
- Ensured data remains persistent through restarts, changed graph to horizontal, added labels for each activity based on comboBox, filtered by activity type over the course of a month.
- Confirmed runs without issue, builds successfully, and contains no conflicts.
- Further refinement capture in other tickets.

![image](https://github.com/user-attachments/assets/67862392-7a1d-409f-9815-b25ee0ddf925)
